### PR TITLE
Fix Zeitwerk compatibility in Railtie middleware registration

### DIFF
--- a/lib/trace_request_id/railtie.rb
+++ b/lib/trace_request_id/railtie.rb
@@ -18,7 +18,7 @@ class TraceRequestId
     def register_sidekiq_client_middleware
       Sidekiq.configure_client do |config|
         config.client_middleware do |chain|
-          chain.add SidekiqClientMiddleware
+          chain.add TraceRequestId::SidekiqClientMiddleware
         end
       end
     end
@@ -26,11 +26,11 @@ class TraceRequestId
     def register_sidekiq_server_middleware
       Sidekiq.configure_server do |config|
         config.client_middleware do |chain|
-          chain.add SidekiqClientMiddleware
+          chain.add TraceRequestId::SidekiqClientMiddleware
         end
 
         config.server_middleware do |chain|
-          chain.add SidekiqServerMiddleware
+          chain.add TraceRequestId::SidekiqServerMiddleware
         end
       end
     end
@@ -38,7 +38,7 @@ class TraceRequestId
     def register_sidekiq_test_middleware
       # attach Sidekiq middleware to Sidekiq:Testing
       Sidekiq::Testing.server_middleware do |chain|
-        chain.add SidekiqServerMiddleware
+        chain.add TraceRequestId::SidekiqServerMiddleware
       end
     end
   end


### PR DESCRIPTION
Use fully qualified class names (TraceRequestId::SidekiqClientMiddleware instead of SidekiqClientMiddleware) to prevent NameError with Zeitwerk autoloader in Rails applications.